### PR TITLE
Fix broken integration test

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/src/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -65,7 +65,7 @@ namespace MartinCostello.BrowserStack.Automate
                 ICollection<SessionItem> sessions = await target.GetSessionsAsync(build.Item.HashedId);
 
                 // Assert
-                sessions.Should().NotBeNullOrEmpty();
+                sessions.Should().NotBeNull();
 
                 sessions.All((p) => !string.IsNullOrEmpty(p.Item.BrowserName));
                 sessions.All((p) => !string.IsNullOrEmpty(p.Item.BrowserVersion));


### PR DESCRIPTION
Fix broken integration test by allowing sessions to be empty for a build (as the build might indeed have no sessions).