### PR TITLE
Remove AppVeyor branch restriction

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 
-branches:
-  only:
-    - master
-
 assembly_info:
   patch: true
   file: AssemblyVersion.cs


### PR DESCRIPTION
Remove the AppVeyor branch restriction as it is stopping builds for tags.