### PR TITLE
Fix typo in project URL

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/project.json
+++ b/src/MartinCostello.BrowserStack.Automate/project.json
@@ -51,7 +51,7 @@
     "iconUrl": "https://martincostello.github.io/browserstack-automate/images/browserstack-logo.png",
     "licenseUrl": "https://github.com/martincostello/browserstack-automate/blob/master/LICENSE",
     "owners": [ "Martin Costello" ],
-    "projectUrl": "https://github.com/martincostello/browserstack-automater",
+    "projectUrl": "https://github.com/martincostello/browserstack-automate",
     "releaseNotes": "See https://github.com/martincostello/browserstack-automate/releases for details.",
     "repository": {
       "type": "git",

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/project.json
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/project.json
@@ -51,7 +51,7 @@
     "iconUrl": "https://martincostello.github.io/browserstack-automate/images/browserstack-logo.png",
     "licenseUrl": "https://github.com/martincostello/browserstack-automate/blob/master/LICENSE",
     "owners": [ "Martin Costello" ],
-    "projectUrl": "https://github.com/martincostello/browserstack-automater",
+    "projectUrl": "https://github.com/martincostello/browserstack-automate",
     "releaseNotes": "See https://github.com/martincostello/browserstack-automate/releases for details.",
     "repository": {
       "type": "git",


### PR DESCRIPTION
Fix typo in the project URL that creates a 404 in the [NuGet package listing](https://www.nuget.org/packages/MartinCostello.BrowserStack.Automate/2.0.0).