### PR TITLE
Fix duplicate NuGet package tag

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/project.json
+++ b/src/MartinCostello.BrowserStack.Automate/project.json
@@ -59,7 +59,7 @@
     },
     "requireLicenseAcceptance": false,
     "summary": ".NET client for the BrowserStack Automate REST API.",
-    "tags": [ "BrowserStack", "BrowserStack Automate" ]
+    "tags": [ "BrowserStack", "Automate" ]
   },
 
   "tooling": {


### PR DESCRIPTION
Fix "BrowserStack" appearing twice as a tag in the NuGet package.