### PR TITLE
Improve Travis CI build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: csharp
-
 sudo: required
 dist: trusty
 
@@ -21,9 +19,6 @@ addons:
     - libicu-dev
     - libssl-dev
     - libunwind8
-
-mono:
-  - latest
 
 install:
   - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 dotnet restore --verbosity minimal
-dotnet build src/MartinCostello.BrowserStack.Automate --framework "netcoreapp1.0"
+dotnet build src/MartinCostello.BrowserStack.Automate --framework "netstandard1.3"
 dotnet test tests/MartinCostello.BrowserStack.Automate.Tests --framework "netcoreapp1.0"
-dotnet pack src/MartinCostello.BrowserStack.Automate --no-build

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 dotnet restore --verbosity minimal
-dotnet build src/MartinCostello.BrowserStack.Automate
+dotnet build src/MartinCostello.BrowserStack.Automate --framework "netcoreapp1.0"
 dotnet test tests/MartinCostello.BrowserStack.Automate.Tests --framework "netcoreapp1.0"
-dotnet pack src/MartinCostello.BrowserStack.Automate
+dotnet pack src/MartinCostello.BrowserStack.Automate --no-build


### PR DESCRIPTION
Improve build time for Travis CI by not using an image that installs Mono.