### PR TITLE
HttpClientFactory Interop

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,10 +2,14 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.0.0-rc4" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.1" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.BrowserStack.Automate
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json;
 
@@ -104,6 +105,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// Deletes the build with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="buildId">The Id of the build to delete.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to delete the build with the specified Id.
         /// </returns>
@@ -113,7 +115,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <exception cref="BrowserStackAutomateException">
         /// The build could not be deleted.
         /// </exception>
-        public virtual async Task DeleteBuildAsync(string buildId)
+        public virtual async Task DeleteBuildAsync(string buildId, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(buildId))
             {
@@ -124,7 +126,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Delete, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                 }
@@ -135,19 +137,20 @@ namespace MartinCostello.BrowserStack.Automate
         /// Deletes the project with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="projectId">The Id of the project to delete.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to delete the project with the specified Id.
         /// </returns>
         /// <exception cref="BrowserStackAutomateException">
         /// The project could not be deleted.
         /// </exception>
-        public virtual async Task DeleteProjectAsync(int projectId)
+        public virtual async Task DeleteProjectAsync(int projectId, CancellationToken cancellationToken = default)
         {
             string relativeUri = string.Format(CultureInfo.InvariantCulture, "projects/{0}.json", projectId);
 
             using (var request = CreateRequest(HttpMethod.Delete, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                 }
@@ -158,13 +161,14 @@ namespace MartinCostello.BrowserStack.Automate
         /// Deletes the session with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="sessionId">The Id of the session to delete.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to delete the session with the specified Id.
         /// </returns>
         /// <exception cref="BrowserStackAutomateException">
         /// The session could not be deleted.
         /// </exception>
-        public virtual async Task DeleteSessionAsync(string sessionId)
+        public virtual async Task DeleteSessionAsync(string sessionId, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(sessionId))
             {
@@ -178,7 +182,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Delete, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                 }
@@ -188,14 +192,15 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets the browsers as an asynchronous operation.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the browsers.
         /// </returns>
-        public virtual async Task<ICollection<Browser>> GetBrowsersAsync()
+        public virtual async Task<ICollection<Browser>> GetBrowsersAsync(CancellationToken cancellationToken = default)
         {
             using (var request = CreateRequest(HttpMethod.Get, "browsers.json"))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<List<Browser>>(response).ConfigureAwait(false);
@@ -206,20 +211,23 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets the builds as an asynchronous operation.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the builds.
         /// </returns>
-        public virtual Task<ICollection<Build>> GetBuildsAsync() => GetBuildsAsync(null, null);
+        public virtual Task<ICollection<Build>> GetBuildsAsync(CancellationToken cancellationToken = default)
+            => GetBuildsAsync(null, null, cancellationToken);
 
         /// <summary>
         /// Gets the builds as an asynchronous operation.
         /// </summary>
         /// <param name="limit">The optional number of builds to return. The default value is 10.</param>
         /// <param name="status">The optional status to filter builds to.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the builds.
         /// </returns>
-        public virtual async Task<ICollection<Build>> GetBuildsAsync(int? limit, string status)
+        public virtual async Task<ICollection<Build>> GetBuildsAsync(int? limit, string status, CancellationToken cancellationToken = default)
         {
             string relativeUri = string.Format(
                 CultureInfo.InvariantCulture,
@@ -228,7 +236,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<List<Build>>(response).ConfigureAwait(false);
@@ -240,16 +248,17 @@ namespace MartinCostello.BrowserStack.Automate
         /// Gets the project with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="projectId">The Id of the project to return.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the project with the specified Id.
         /// </returns>
-        public virtual async Task<ProjectDetailItem> GetProjectAsync(int projectId)
+        public virtual async Task<ProjectDetailItem> GetProjectAsync(int projectId, CancellationToken cancellationToken = default)
         {
             string relativeUri = string.Format(CultureInfo.InvariantCulture, "projects/{0}.json", projectId);
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<ProjectDetailItem>(response).ConfigureAwait(false);
@@ -260,14 +269,15 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets the projects as an asynchronous operation.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the projects.
         /// </returns>
-        public virtual async Task<ICollection<Project>> GetProjectsAsync()
+        public virtual async Task<ICollection<Project>> GetProjectsAsync(CancellationToken cancellationToken = default)
         {
             using (var request = CreateRequest(HttpMethod.Get, "projects.json"))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<List<Project>>(response).ConfigureAwait(false);
@@ -279,13 +289,14 @@ namespace MartinCostello.BrowserStack.Automate
         /// Gets the session associated with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="sessionId">The session Id to return.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the session with the specified Id.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual async Task<SessionDetail> GetSessionAsync(string sessionId)
+        public virtual async Task<SessionDetail> GetSessionAsync(string sessionId, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(sessionId))
             {
@@ -299,7 +310,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<SessionDetail>(response).ConfigureAwait(false);
@@ -312,13 +323,14 @@ namespace MartinCostello.BrowserStack.Automate
         /// </summary>
         /// <param name="buildId">The build Id to return the logs for.</param>
         /// <param name="sessionId">The session Id to return the logs for.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session with the specified Ids.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual async Task<string> GetSessionLogsAsync(string buildId, string sessionId)
+        public virtual async Task<string> GetSessionLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(buildId))
             {
@@ -338,7 +350,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     if (response.StatusCode == HttpStatusCode.NotFound)
                     {
@@ -356,13 +368,15 @@ namespace MartinCostello.BrowserStack.Automate
         /// Gets the sessions associated with the specified build Id as an asynchronous operation.
         /// </summary>
         /// <param name="buildId">The build Id of the sessions to return.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the sessions for the specified build Id.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="buildId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual Task<ICollection<Session>> GetSessionsAsync(string buildId) => GetSessionsAsync(buildId, null, null);
+        public virtual Task<ICollection<Session>> GetSessionsAsync(string buildId, CancellationToken cancellationToken = default)
+            => GetSessionsAsync(buildId, null, null, cancellationToken);
 
         /// <summary>
         /// Gets the sessions associated with the specified build Id as an asynchronous operation.
@@ -370,13 +384,18 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="buildId">The build Id of the sessions to return.</param>
         /// <param name="limit">The optional number of builds to return. The default value is 10.</param>
         /// <param name="status">The optional status to filter builds to.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the sessions for the specified build Id.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="buildId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual async Task<ICollection<Session>> GetSessionsAsync(string buildId, int? limit, string status)
+        public virtual async Task<ICollection<Session>> GetSessionsAsync(
+            string buildId,
+            int? limit,
+            string status,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(buildId))
             {
@@ -391,7 +410,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<List<Session>>(response).ConfigureAwait(false);
@@ -402,14 +421,15 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets the status of the <c>BrowserStack</c> Automate plan as an asynchronous operation.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the status of the Automate plan.
         /// </returns>
-        public virtual async Task<AutomatePlanStatus> GetStatusAsync()
+        public virtual async Task<AutomatePlanStatus> GetStatusAsync(CancellationToken cancellationToken = default)
         {
             using (var request = CreateRequest(HttpMethod.Get, "plan.json"))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<AutomatePlanStatus>(response).ConfigureAwait(false);
@@ -420,20 +440,21 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Recycles the current access key as an asynchronous operation.
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to recycle the access key which returns the new and old access keys.
         /// </returns>
         /// <remarks>
         /// The credentials used by the current instance are automatically updated if successful.
         /// </remarks>
-        public virtual async Task<RecycleAccessKeyResult> RecycleAccessKeyAsync()
+        public virtual async Task<RecycleAccessKeyResult> RecycleAccessKeyAsync(CancellationToken cancellationToken = default)
         {
             var value = new { };
             var json = SerializeAsJson(value);
 
             using (var request = CreateRequest(HttpMethod.Put, "recycle_key.json", json))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
 
@@ -455,13 +476,18 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="sessionId">The session Id to set the status of.</param>
         /// <param name="status">The new status.</param>
         /// <param name="reason">An optional reason to specify.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the sessions for the specified build Id.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> or <paramref name="status"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual async Task<Session> SetSessionStatusAsync(string sessionId, string status, string reason)
+        public virtual async Task<Session> SetSessionStatusAsync(
+            string sessionId,
+            string status,
+            string reason,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(sessionId))
             {
@@ -488,7 +514,7 @@ namespace MartinCostello.BrowserStack.Automate
 
             using (var request = CreateRequest(HttpMethod.Put, relativeUri, json))
             {
-                using (var response = await Client.SendAsync(request).ConfigureAwait(false))
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
                     return await DeserializeAsync<Session>(response).ConfigureAwait(false);

--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClientExtensions.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClientExtensions.cs
@@ -28,14 +28,14 @@ namespace MartinCostello.BrowserStack.Automate
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public static async Task<Session> SetSessionCompletedAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
+        public static Task<Session> SetSessionCompletedAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
 
-            return await client.SetSessionStatusAsync(sessionId, SessionStatuses.Completed, reason);
+            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Completed, reason);
         }
 
         /// <summary>
@@ -53,14 +53,14 @@ namespace MartinCostello.BrowserStack.Automate
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public static async Task<Session> SetSessionErrorAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
+        public static Task<Session> SetSessionErrorAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
 
-            return await client.SetSessionStatusAsync(sessionId, SessionStatuses.Error, reason);
+            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Error, reason);
         }
     }
 }

--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateError.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateError.cs
@@ -9,6 +9,9 @@ namespace MartinCostello.BrowserStack.Automate
     /// A class representing a BrowserStack Automate error.
     /// </summary>
     [System.Diagnostics.DebuggerDisplay("{" + nameof(Message) + "}")]
+#if NET451
+    [System.Serializable]
+#endif
     public class BrowserStackAutomateError
     {
         /// <summary>

--- a/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
+++ b/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
@@ -4,6 +4,7 @@
     <DebugType>full</DebugType>
     <Description>.NET client for the BrowserStack Automate REST API.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CA1056</NoWarn>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -523,7 +523,7 @@ namespace MartinCostello.BrowserStack.Automate
                 .Should()
                 .Throw<ArgumentOutOfRangeException>()
                 .Where((p) => p.ParamName == "limit")
-                .Where((p) => p.Message.StartsWith("The limit value cannot be less than one."))
+                .Where((p) => p.Message.StartsWith("The limit value cannot be less than one.", StringComparison.Ordinal))
                 .And
                 .ActualValue.Should().Be(0);
         }
@@ -544,7 +544,7 @@ namespace MartinCostello.BrowserStack.Automate
                 .Should()
                 .Throw<ArgumentOutOfRangeException>()
                 .Where((p) => p.ParamName == "limit")
-                .Where((p) => p.Message.StartsWith("The limit value cannot be less than one."))
+                .Where((p) => p.Message.StartsWith("The limit value cannot be less than one.", StringComparison.Ordinal))
                 .And
                 .ActualValue.Should().Be(0);
         }

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -7,8 +7,12 @@ namespace MartinCostello.BrowserStack.Automate
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using FluentAssertions;
+    using Microsoft.Extensions.DependencyInjection;
+    using Polly;
+    using Polly.CircuitBreaker;
     using Xunit;
 
     /// <summary>
@@ -619,6 +623,36 @@ namespace MartinCostello.BrowserStack.Automate
             actual.Should().NotBeNull();
             actual.OldKey.Should().Be(expected);
             actual.NewKey.Should().NotBe(expected);
+        }
+
+        [Fact]
+        public static async Task Can_Configure_With_HttpClient_Factory()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Create a Polly policy that is a pre-isolated circuit breaker that is guaranteed to fail
+            var policy = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.MaxValue);
+            policy.Isolate();
+
+            services
+                .AddPolicyRegistry()
+                .Add(policy.PolicyKey, policy.AsAsyncPolicy<HttpResponseMessage>());
+
+            services
+                .AddSingleton<BrowserStackAutomateClient>()
+                .AddHttpClient("BrowserStack Automate")
+                .AddTypedClient((httpClient) => new BrowserStackAutomateClient("a", "b", httpClient))
+                .ConfigureHttpClient((httpClient) => httpClient.Timeout = TimeSpan.FromSeconds(10))
+                .AddPolicyHandlerFromRegistry(policy.PolicyKey);
+
+            using (var provider = services.BuildServiceProvider())
+            {
+                var client = provider.GetRequiredService<BrowserStackAutomateClient>();
+
+                // Act and Assert
+                await Assert.ThrowsAsync<IsolatedCircuitException>(() => client.GetBuildsAsync());
+            }
         }
 
         /// <summary>

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
@@ -13,8 +13,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Polly" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
@@ -1,6 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Tests for MartinCostello.BrowserStack.Automate.</Description>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA1707;CA2007</NoWarn>
+    <RootNamespace>MartinCostello.BrowserStack.Automate</RootNamespace>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <!-- HACK: https://github.com/Microsoft/vstest/issues/1607#issuecomment-394521170 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
  * Support injection of `HttpClient` for interop with [HttpClientFactory](https://github.com/aspnet/HttpClientFactory).
  * Add support for usage of `CancellationToken`.
  * Use `ConfigureAwait(false)` for awaitable calls.