### PR TITLE
Add new methods

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
@@ -64,7 +64,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets the base URI of the BrowserStack Automate REST API.
         /// </summary>
-        public static Uri ApiBaseAddress => new Uri("https://www.browserstack.com/automate/", UriKind.Absolute);
+        public static Uri ApiBaseAddress => new Uri("https://api.browserstack.com/automate/", UriKind.Absolute);
 
         /// <summary>
         /// Gets the user name in use.

--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
@@ -6,6 +6,7 @@ namespace MartinCostello.BrowserStack.Automate
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -134,6 +135,48 @@ namespace MartinCostello.BrowserStack.Automate
         }
 
         /// <summary>
+        /// Deletes the builds with the specified Ids as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildIds">The Ids of the builds to delete.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to delete the build with the specified Id.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="buildIds"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="buildIds"/> is empty.
+        /// </exception>
+        /// <exception cref="BrowserStackAutomateException">
+        /// The builds could not be deleted.
+        /// </exception>
+        public virtual async Task DeleteBuildsAsync(ICollection<string> buildIds, CancellationToken cancellationToken = default)
+        {
+            if (buildIds == null)
+            {
+                throw new ArgumentNullException(nameof(buildIds));
+            }
+
+            if (buildIds.Count < 1)
+            {
+                throw new ArgumentException("No build Ids specified.", nameof(buildIds));
+            }
+
+            string query = string.Join("&", buildIds.Select((p) => $"buildId={Uri.EscapeDataString(p)}"));
+
+            string relativeUri = string.Format(CultureInfo.InvariantCulture, "builds?{0}", query);
+
+            using (var request = CreateRequest(HttpMethod.Delete, relativeUri))
+            {
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                {
+                    await EnsureSuccessAsync(response).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
         /// Deletes the project with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="projectId">The Id of the project to delete.</param>
@@ -190,6 +233,48 @@ namespace MartinCostello.BrowserStack.Automate
         }
 
         /// <summary>
+        /// Deletes the sessions with the specified Ids as an asynchronous operation.
+        /// </summary>
+        /// <param name="sessionIds">The Ids of the sessions to delete.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to delete the sessions with the specified Ids.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="sessionIds"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="sessionIds"/> is empty.
+        /// </exception>
+        /// <exception cref="BrowserStackAutomateException">
+        /// The sessions could not be deleted.
+        /// </exception>
+        public virtual async Task DeleteSessionsAsync(ICollection<string> sessionIds, CancellationToken cancellationToken = default)
+        {
+            if (sessionIds == null)
+            {
+                throw new ArgumentNullException(nameof(sessionIds));
+            }
+
+            if (sessionIds.Count < 1)
+            {
+                throw new ArgumentException("No session Ids specified.", nameof(sessionIds));
+            }
+
+            string query = string.Join("&", sessionIds.Select((p) => $"sessionId={Uri.EscapeDataString(p)}"));
+
+            string relativeUri = string.Format(CultureInfo.InvariantCulture, "session?{0}", query);
+
+            using (var request = CreateRequest(HttpMethod.Delete, relativeUri))
+            {
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                {
+                    await EnsureSuccessAsync(response).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the browsers as an asynchronous operation.
         /// </summary>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
@@ -216,23 +301,28 @@ namespace MartinCostello.BrowserStack.Automate
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the builds.
         /// </returns>
         public virtual Task<ICollection<Build>> GetBuildsAsync(CancellationToken cancellationToken = default)
-            => GetBuildsAsync(null, null, cancellationToken);
+            => GetBuildsAsync(null, null, null, cancellationToken);
 
         /// <summary>
         /// Gets the builds as an asynchronous operation.
         /// </summary>
         /// <param name="limit">The optional number of builds to return. The default value is 10.</param>
+        /// <param name="offset">The optional offset for builds to return. The default value is 0.</param>
         /// <param name="status">The optional status to filter builds to.</param>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the builds.
         /// </returns>
-        public virtual async Task<ICollection<Build>> GetBuildsAsync(int? limit, string status, CancellationToken cancellationToken = default)
+        public virtual async Task<ICollection<Build>> GetBuildsAsync(
+            int? limit,
+            int? offset,
+            string status,
+            CancellationToken cancellationToken = default)
         {
             string relativeUri = string.Format(
                 CultureInfo.InvariantCulture,
                 "builds.json{0}",
-                BuildQuery(limit, status));
+                BuildQuery(limit, offset, status));
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
@@ -325,44 +415,62 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="sessionId">The session Id to return the logs for.</param>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
-        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session with the specified Ids.
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and
+        /// session with the specified Ids as a string.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public virtual async Task<string> GetSessionLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
-        {
-            if (string.IsNullOrWhiteSpace(buildId))
-            {
-                throw new ArgumentException("No build Id specified.", nameof(buildId));
-            }
+        public virtual Task<string> GetSessionLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
+            => GetLogsAsync(buildId, sessionId, "logs", cancellationToken);
 
-            if (string.IsNullOrWhiteSpace(sessionId))
-            {
-                throw new ArgumentException("No session Id specified.", nameof(sessionId));
-            }
+        /// <summary>
+        /// Gets the raw session Appium logs associated with the specified build and session Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildId">The build Id to return the logs for.</param>
+        /// <param name="sessionId">The session Id to return the logs for.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session
+        /// with the specified Ids as a string.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<string> GetSessionAppiumLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
+            => GetLogsAsync(buildId, sessionId, "appiumlogs", cancellationToken);
 
-            string relativeUri = string.Format(
-                CultureInfo.InvariantCulture,
-                "builds/{0}/sessions/{1}/logs.json",
-                Uri.EscapeDataString(buildId),
-                Uri.EscapeDataString(sessionId));
+        /// <summary>
+        /// Gets the session console logs associated with the specified build and session Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildId">The build Id to return the logs for.</param>
+        /// <param name="sessionId">The session Id to return the logs for.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session
+        /// with the specified Ids as a string.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<string> GetSessionConsoleLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
+            => GetLogsAsync(buildId, sessionId, "consolelogs", cancellationToken);
 
-            using (var request = CreateRequest(HttpMethod.Get, relativeUri))
-            {
-                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
-                {
-                    if (response.StatusCode == HttpStatusCode.NotFound)
-                    {
-                        // Returns an HTML error page, so just return empty if there are no logs
-                        return string.Empty;
-                    }
-
-                    response.EnsureSuccessStatusCode();
-                    return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                }
-            }
-        }
+        /// <summary>
+        /// Gets the session network logs associated with the specified build and session Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildId">The build Id to return the logs for.</param>
+        /// <param name="sessionId">The session Id to return the logs for.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session
+        /// with the specified Ids as a string in HAR (HTTP Archive) format.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<string> GetSessionNetworkLogsAsync(string buildId, string sessionId, CancellationToken cancellationToken = default)
+            => GetLogsAsync(buildId, sessionId, "networklogs", cancellationToken);
 
         /// <summary>
         /// Gets the sessions associated with the specified build Id as an asynchronous operation.
@@ -376,14 +484,15 @@ namespace MartinCostello.BrowserStack.Automate
         /// <paramref name="buildId"/> is <see langword="null"/> or white space.
         /// </exception>
         public virtual Task<ICollection<Session>> GetSessionsAsync(string buildId, CancellationToken cancellationToken = default)
-            => GetSessionsAsync(buildId, null, null, cancellationToken);
+            => GetSessionsAsync(buildId, null, null, null, cancellationToken);
 
         /// <summary>
         /// Gets the sessions associated with the specified build Id as an asynchronous operation.
         /// </summary>
         /// <param name="buildId">The build Id of the sessions to return.</param>
-        /// <param name="limit">The optional number of builds to return. The default value is 10.</param>
-        /// <param name="status">The optional status to filter builds to.</param>
+        /// <param name="limit">The optional number of sessions to return. The default value is 10.</param>
+        /// <param name="offset">The optional offset for sessions to return. The default value is 0.</param>
+        /// <param name="status">The optional status to filter sessions to.</param>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the sessions for the specified build Id.
@@ -394,6 +503,7 @@ namespace MartinCostello.BrowserStack.Automate
         public virtual async Task<ICollection<Session>> GetSessionsAsync(
             string buildId,
             int? limit,
+            int? offset,
             string status,
             CancellationToken cancellationToken = default)
         {
@@ -406,7 +516,7 @@ namespace MartinCostello.BrowserStack.Automate
                 CultureInfo.InvariantCulture,
                 "builds/{0}/sessions.json{1}",
                 Uri.EscapeDataString(buildId),
-                BuildQuery(limit, status));
+                BuildQuery(limit, offset, status));
 
             using (var request = CreateRequest(HttpMethod.Get, relativeUri))
             {
@@ -471,6 +581,87 @@ namespace MartinCostello.BrowserStack.Automate
         }
 
         /// <summary>
+        /// Sets the name of the build with the specified Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildId">The build Id to set the name of.</param>
+        /// <param name="name">The new name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the name for the specified build Id.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<Build> SetBuildNameAsync(
+            int buildId,
+            string name,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("No name specified.", nameof(name));
+            }
+
+            string relativeUri = string.Format(CultureInfo.InvariantCulture, "builds/{0}.json", buildId);
+
+            return SetNameAsync<Build>(relativeUri, name, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the name of the project with the specified Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="projectId">The project Id to set the name of.</param>
+        /// <param name="name">The new name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the name for the specified project Id.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<Project> SetProjectNameAsync(
+            int projectId,
+            string name,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("No name specified.", nameof(name));
+            }
+
+            string relativeUri = string.Format(CultureInfo.InvariantCulture, "projects/{0}.json", projectId);
+
+            return SetNameAsync<Project>(relativeUri, name, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the name of the session with the specified Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="sessionId">The session Id to set the name of.</param>
+        /// <param name="name">The new name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the name for the specified session Id.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="name"/> is <see langword="null"/> or white space.
+        /// </exception>
+        public virtual Task<Session> SetSessionNameAsync(
+            string sessionId,
+            string name,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("No name specified.", nameof(name));
+            }
+
+            string relativeUri = string.Format(CultureInfo.InvariantCulture, "sessions/{0}.json", sessionId);
+
+            return SetNameAsync<Session>(relativeUri, name, cancellationToken);
+        }
+
+        /// <summary>
         /// Sets the status of the session with the specified Id as an asynchronous operation.
         /// </summary>
         /// <param name="sessionId">The session Id to set the status of.</param>
@@ -478,7 +669,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="reason">An optional reason to specify.</param>
         /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
-        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the sessions for the specified build Id.
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the status for the specified session Id.
         /// </returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> or <paramref name="status"/> is <see langword="null"/> or white space.
@@ -555,11 +746,12 @@ namespace MartinCostello.BrowserStack.Automate
         /// Builds the query string parameters to use, if any, for the specified parameters.
         /// </summary>
         /// <param name="limit">The limit to use, if any.</param>
+        /// <param name="offset">The offset to use, if any.</param>
         /// <param name="status">The status to filter to, if any.</param>
         /// <returns>
         /// The query string to use, if any.
         /// </returns>
-        private static string BuildQuery(int? limit, string status)
+        private static string BuildQuery(int? limit, int? offset, string status)
         {
             var builder = new StringBuilder();
 
@@ -571,6 +763,16 @@ namespace MartinCostello.BrowserStack.Automate
                 }
 
                 builder.AppendFormat(CultureInfo.InvariantCulture, "limit={0}", limit.Value);
+            }
+
+            if (offset.HasValue)
+            {
+                if (offset < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset), offset.Value, "The offset value cannot be less than zero.");
+                }
+
+                builder.AppendFormat(CultureInfo.InvariantCulture, "offset={0}", offset.Value);
             }
 
             if (!string.IsNullOrEmpty(status))
@@ -659,6 +861,85 @@ namespace MartinCostello.BrowserStack.Automate
             {
                 request.Dispose();
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Gets the specified type of logs associated with the specified build and session Id as an asynchronous operation.
+        /// </summary>
+        /// <param name="buildId">The build Id to return the logs for.</param>
+        /// <param name="sessionId">The session Id to return the logs for.</param>
+        /// <param name="logType">The log type to retrieve.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the logs for the build and session with the specified Ids.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="buildId"/> or <paramref name="sessionId"/> is <see langword="null"/> or white space.
+        /// </exception>
+        private async Task<string> GetLogsAsync(
+            string buildId,
+            string sessionId,
+            string logType,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(buildId))
+            {
+                throw new ArgumentException("No build Id specified.", nameof(buildId));
+            }
+
+            if (string.IsNullOrWhiteSpace(sessionId))
+            {
+                throw new ArgumentException("No session Id specified.", nameof(sessionId));
+            }
+
+            string relativeUri = string.Format(
+                CultureInfo.InvariantCulture,
+                "builds/{0}/sessions/{1}/{2}",
+                Uri.EscapeDataString(buildId),
+                Uri.EscapeDataString(sessionId),
+                Uri.EscapeDataString(logType));
+
+            using (var request = CreateRequest(HttpMethod.Get, relativeUri))
+            {
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                {
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        // Returns an HTML error page, so just return empty if there are no logs
+                        return string.Empty;
+                    }
+
+                    response.EnsureSuccessStatusCode();
+                    return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the name of the session with the specified Id as an asynchronous operation.
+        /// </summary>
+        /// <typeparam name="T">The type of the resource.</typeparam>
+        /// <param name="relativeUri">The relative URI of the resource to set the name of.</param>
+        /// <param name="name">The new name.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the name for the specified resource.
+        /// </returns>
+        private async Task<T> SetNameAsync<T>(
+            string relativeUri,
+            string name,
+            CancellationToken cancellationToken = default)
+        {
+            var json = SerializeAsJson(new { name });
+
+            using (var request = CreateRequest(HttpMethod.Put, relativeUri, json))
+            {
+                using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                {
+                    await EnsureSuccessAsync(response).ConfigureAwait(false);
+                    return await DeserializeAsync<T>(response).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClientExtensions.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClientExtensions.cs
@@ -5,6 +5,7 @@ namespace MartinCostello.BrowserStack.Automate
 {
     using System;
     using System.ComponentModel;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -19,6 +20,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="client">The <c>BrowserStack</c> Automate client.</param>
         /// <param name="sessionId">The session Id to set the status of.</param>
         /// <param name="reason">An optional reason to specify.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the status of the session with the specified Id as having completed.
         /// </returns>
@@ -28,14 +30,18 @@ namespace MartinCostello.BrowserStack.Automate
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public static Task<Session> SetSessionCompletedAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
+        public static Task<Session> SetSessionCompletedAsync(
+            this BrowserStackAutomateClient client,
+            string sessionId,
+            string reason,
+            CancellationToken cancellationToken = default)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
 
-            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Completed, reason);
+            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Completed, reason, cancellationToken);
         }
 
         /// <summary>
@@ -44,6 +50,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <param name="client">The <c>BrowserStack</c> Automate client.</param>
         /// <param name="sessionId">The session Id to set the status of.</param>
         /// <param name="reason">An optional reason to specify.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation to set the status of the session with the specified Id as having an error.
         /// </returns>
@@ -53,14 +60,18 @@ namespace MartinCostello.BrowserStack.Automate
         /// <exception cref="ArgumentException">
         /// <paramref name="sessionId"/> is <see langword="null"/> or white space.
         /// </exception>
-        public static Task<Session> SetSessionErrorAsync(this BrowserStackAutomateClient client, string sessionId, string reason)
+        public static Task<Session> SetSessionErrorAsync(
+            this BrowserStackAutomateClient client,
+            string sessionId,
+            string reason,
+            CancellationToken cancellationToken = default)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
 
-            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Error, reason);
+            return client.SetSessionStatusAsync(sessionId, SessionStatuses.Error, reason, cancellationToken);
         }
     }
 }

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -27,6 +27,7 @@ namespace MartinCostello.BrowserStack.Automate
             BrowserStackAutomateClient target = CreateAuthenticatedClient();
 
             int? limit;
+            int? offset;
             string status;
 
             // Act
@@ -113,10 +114,11 @@ namespace MartinCostello.BrowserStack.Automate
 
                 // Arrange
                 limit = 5;
+                offset = 1;
                 status = null;
 
                 // Act
-                sessions = await target.GetSessionsAsync(build.HashedId, limit, status);
+                sessions = await target.GetSessionsAsync(build.HashedId, limit, offset, status);
 
                 // Assert
                 sessions.Should().NotBeNull();
@@ -133,7 +135,7 @@ namespace MartinCostello.BrowserStack.Automate
                 status = SessionStatuses.Done;
 
                 // Act
-                sessions = await target.GetSessionsAsync(build.HashedId, limit, status);
+                sessions = await target.GetSessionsAsync(build.HashedId, limit, offset, status);
 
                 // Assert
                 sessions.Should().NotBeNull();
@@ -149,7 +151,7 @@ namespace MartinCostello.BrowserStack.Automate
                 status = SessionStatuses.Done;
 
                 // Act
-                sessions = await target.GetSessionsAsync(build.HashedId, limit, status);
+                sessions = await target.GetSessionsAsync(build.HashedId, limit, offset, status);
 
                 // Assert
                 sessions.Should().NotBeNull();
@@ -162,15 +164,25 @@ namespace MartinCostello.BrowserStack.Automate
 
                     // Act (no Assert)
                     await target.GetSessionLogsAsync(build.HashedId, session.HashedId);
+
+                    // Act (no Assert)
+                    await target.GetSessionAppiumLogsAsync(build.HashedId, session.HashedId);
+
+                    // Act (no Assert)
+                    await target.GetSessionConsoleLogsAsync(build.HashedId, session.HashedId);
+
+                    // Act (no Assert)
+                    await target.GetSessionNetworkLogsAsync(build.HashedId, session.HashedId);
                 }
             }
 
             // Arrange
             limit = 5;
+            offset = 1;
             status = null;
 
             // Act
-            builds = await target.GetBuildsAsync(limit, status);
+            builds = await target.GetBuildsAsync(limit, offset, status);
 
             // Assert
             builds.Should().NotBeNull();
@@ -184,10 +196,11 @@ namespace MartinCostello.BrowserStack.Automate
 
             // Arrange
             limit = null;
+            offset = null;
             status = BuildStatuses.Done;
 
             // Act
-            builds = await target.GetBuildsAsync(limit, status);
+            builds = await target.GetBuildsAsync(limit, offset, status);
 
             // Assert
             builds.Should().NotBeNull();
@@ -205,7 +218,7 @@ namespace MartinCostello.BrowserStack.Automate
             projects.Should().NotBeNullOrEmpty();
             projects.Should().NotContainNulls();
 
-            DateTime minimumDate = new DateTime(2011, 1, 1, 0, 0, 0);
+            var minimumDate = new DateTime(2011, 1, 1, 0, 0, 0);
 
             foreach (var project in projects)
             {
@@ -315,6 +328,40 @@ namespace MartinCostello.BrowserStack.Automate
                 .ParamName.Should().Be("buildId");
         }
 
+        [Fact]
+        public static void DeleteBuildsAsync_Throws_If_BuildIds_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            ICollection<string> buildIds = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.DeleteBuildsAsync(buildIds))
+                .Should()
+                .Throw<ArgumentNullException>()
+                .And
+                .ParamName.Should().Be("buildIds");
+        }
+
+        [Fact]
+        public static void DeleteBuildsAsync_Throws_If_BuildIds_Is_Empty()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            var buildIds = Array.Empty<string>();
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.DeleteBuildsAsync(buildIds))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("buildIds");
+        }
+
         [RequiresServiceCredentialsFact]
         public static void DeleteBuildAsync_Throws_If_BuildId_Is_Not_Found()
         {
@@ -364,6 +411,40 @@ namespace MartinCostello.BrowserStack.Automate
                 .Throw<ArgumentException>()
                 .And
                 .ParamName.Should().Be("sessionId");
+        }
+
+        [Fact]
+        public static void DeleteSessionsAsync_Throws_If_SessionIds_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            ICollection<string> sessionIds = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.DeleteSessionsAsync(sessionIds))
+                .Should()
+                .Throw<ArgumentNullException>()
+                .And
+                .ParamName.Should().Be("sessionIds");
+        }
+
+        [Fact]
+        public static void DeleteSessionsAsync_Throws_If_SessionIds_Is_Empty()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            var sessionIds = Array.Empty<string>();
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.DeleteSessionsAsync(sessionIds))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("sessionIds");
         }
 
         [RequiresServiceCredentialsFact]
@@ -454,6 +535,114 @@ namespace MartinCostello.BrowserStack.Automate
         }
 
         [Fact]
+        public static void GetSessionAppiumLogsAsync_Throws_If_BuildId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = null;
+            string sessionId = Guid.NewGuid().ToString();
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionAppiumLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("buildId");
+        }
+
+        [Fact]
+        public static void GetSessionAppiumLogsAsync_Throws_If_SessionId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = Guid.NewGuid().ToString();
+            string sessionId = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("sessionId");
+        }
+
+        [Fact]
+        public static void GetSessionConsoleLogsAsync_Throws_If_BuildId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = null;
+            string sessionId = Guid.NewGuid().ToString();
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionConsoleLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("buildId");
+        }
+
+        [Fact]
+        public static void GetSessionConsoleLogsAsync_Throws_If_SessionId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = Guid.NewGuid().ToString();
+            string sessionId = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionConsoleLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("sessionId");
+        }
+
+        [Fact]
+        public static void GetSessionNetworkLogsAsync_Throws_If_BuildId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = null;
+            string sessionId = Guid.NewGuid().ToString();
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionNetworkLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("buildId");
+        }
+
+        [Fact]
+        public static void GetSessionNetworkLogsAsync_Throws_If_SessionId_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string buildId = Guid.NewGuid().ToString();
+            string sessionId = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionNetworkLogsAsync(buildId, sessionId))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("sessionId");
+        }
+
+        [Fact]
         public static void GetSessionsAsync_Throws_If_BuildId_Is_Null()
         {
             // Arrange
@@ -468,6 +657,60 @@ namespace MartinCostello.BrowserStack.Automate
                 .Throw<ArgumentException>()
                 .And
                 .ParamName.Should().Be("buildId");
+        }
+
+        [Fact]
+        public static void SetBuildNameAsync_Throws_If_Name_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            int buildId = 1;
+            string name = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.SetBuildNameAsync(buildId, name))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("name");
+        }
+
+        [Fact]
+        public static void SetProjectNameAsync_Throws_If_Name_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            int projectId = 1;
+            string name = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.SetProjectNameAsync(projectId, name))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("name");
+        }
+
+        [Fact]
+        public static void SetSessionNameAsync_Throws_If_Name_Is_Null()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string sessionId = "x";
+            string name = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.SetSessionNameAsync(sessionId, name))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .ParamName.Should().Be("name");
         }
 
         [Fact]
@@ -515,11 +758,12 @@ namespace MartinCostello.BrowserStack.Automate
             BrowserStackAutomateClient target = CreateClient();
 
             int? limit = 0;
+            int? offset = 0;
             string status = null;
 
             // Act and Assert
             target
-                .Awaiting((p) => p.GetBuildsAsync(limit, status))
+                .Awaiting((p) => p.GetBuildsAsync(limit, offset, status))
                 .Should()
                 .Throw<ArgumentOutOfRangeException>()
                 .Where((p) => p.ParamName == "limit")
@@ -536,17 +780,61 @@ namespace MartinCostello.BrowserStack.Automate
 
             string sessionId = "x";
             int? limit = 0;
+            int? offset = 0;
             string status = null;
 
             // Act and Assert
             target
-                .Awaiting((p) => p.GetSessionsAsync(sessionId, limit, status))
+                .Awaiting((p) => p.GetSessionsAsync(sessionId, limit, offset, status))
                 .Should()
                 .Throw<ArgumentOutOfRangeException>()
                 .Where((p) => p.ParamName == "limit")
                 .Where((p) => p.Message.StartsWith("The limit value cannot be less than one.", StringComparison.Ordinal))
                 .And
                 .ActualValue.Should().Be(0);
+        }
+
+        [Fact]
+        public static void GetBuildsAsync_Throws_If_Offset_Is_Less_Than_Zero()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            int? limit = 1;
+            int? offset = -1;
+            string status = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetBuildsAsync(limit, offset, status))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>()
+                .Where((p) => p.ParamName == "offset")
+                .Where((p) => p.Message.StartsWith("The offset value cannot be less than zero.", StringComparison.Ordinal))
+                .And
+                .ActualValue.Should().Be(-1);
+        }
+
+        [Fact]
+        public static void GetSessionsAsync_Throws_If_Offset_Is_Less_Than_Zero()
+        {
+            // Arrange
+            BrowserStackAutomateClient target = CreateClient();
+
+            string sessionId = "x";
+            int? limit = 1;
+            int? offset = -1;
+            string status = null;
+
+            // Act and Assert
+            target
+                .Awaiting((p) => p.GetSessionsAsync(sessionId, limit, offset, status))
+                .Should()
+                .Throw<ArgumentOutOfRangeException>()
+                .Where((p) => p.ParamName == "offset")
+                .Where((p) => p.Message.StartsWith("The offset value cannot be less than zero.", StringComparison.Ordinal))
+                .And
+                .ActualValue.Should().Be(-1);
         }
 
         [RequiresServiceCredentialsFact(Skip = "Test can only be run manually to prevent accidental destruction of data.")]


### PR DESCRIPTION
  * Expose new BrowserStack Automate API functionality:
    * Rename builds, projects and sessions.
    * Delete multiple builds and sessions.
    * Get Appium, Console and Network logs.
    * Support `offset` query string parameter for pagination.
  * Update BrowserStack Automate API base URI.
  * Add more `CancellationToken` parameters.
  * Fix incorrect XML documentation.