### PR TITLE
Update analyzers and Community docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+To contribute changes (source code, scripts, configuration) to this repository please follow the steps below. These steps are a guideline for contributing and do not necessarily need to be followed for all changes.
+
+   1. If you intend to fix a bug please create an issue before forking the repository.
+    1. Fork the `master` branch of this repository from the latest commit.
+    1. Create a branch from your fork's `master` branch to help isolate your changes from any further work on `master`. If fixing an issue try to reference its name in your branch name (e.g. `issue-42`) to make changes easier to track the changes.
+    1. Work on your proposed changes on your fork. If you are fixing an issue include at least one unit test that reproduces it if the code changes to fix it have not been applied; if you are adding new functionality please include unit tests appropriate to the changes you are making. The [code coverage figure](https://codecov.io/gh/martincostello/browserstack-automate) should be maintained where possible.
+    1. When you think your changes are complete, test that the code builds cleanly using `Build.ps1`/`build.sh`. There should be no compiler warnings and all tests should pass.
+    1. Once your changes build cleanly locally submit a Pull Request back to the `master` branch from your fork's branch. Ideally commits to your branch should be squashed before creating the Pull Request. If the Pull Request fixes an issue please reference it in the title and/or description. Please keep changes focused around a specific topic rather than include multiple types of changes in a single Pull Request.
+    1. After your Pull Request is created it will build against the repository's continuous integrations.
+    1. Once the Pull Request has been reviewed by the project's [contributors](https://github.com/martincostello/browserstack-automate/graphs/contributors) and the status checks pass your Pull Request will be merged back to the `master` branch, assuming that the changes are deemed appropriate.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected behaviour
+
+_Explain what you expected to happen._
+
+### Actual behaviour
+
+_Explain what actually happened. If an exception occurred, please include a stack trace if available._
+
+### Steps to reproduce
+
+_A concise and repeatable example of how to illustrate the issue, including any screenshots if relevant._

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a bug report to help us improve the library
+---
+
+**Describe the bug**
+_A clear and concise description of what the bug is._
+
+**Steps To reproduce**
+_A concise, repeatable, example of how to reproduce the issue._
+
+**Expected behaviour**
+_A clear and concise description of what you expected to happen._
+
+**Actual behaviour**
+_A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available._
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information:**
+ - OS: [e.g. Windows 10]
+ - Library Version [e.g. 3.0.0]
+ - .NET version [e.g. output from `dotnet --info`]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for a feature of this library
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. For example: _I'm always frustrated when [...]_
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+_Summarise the changes this Pull Request makes._
+
+_Please include a reference to a GitHub issue if appropriate._

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+daysUntilStale: 56
+daysUntilClose: 7
+exemptLabels:
+  - blocked
+  - pinned
+  - security
+staleLabel: wontfix
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: Closed automatically due to inactivity.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .dotnetcli
+.idea
 .metadata
 .settings
 .vs

--- a/Build.ps1
+++ b/Build.ps1
@@ -83,7 +83,8 @@ function DotNetPack {
 
     if ($VersionSuffix) {
         & $dotnet pack $Project --output $OutputPath --configuration $Configuration --version-suffix "$VersionSuffix" --include-symbols --include-source
-    } else {
+    }
+    else {
         & $dotnet pack $Project --output $OutputPath --configuration $Configuration --include-symbols --include-source
     }
     if ($LASTEXITCODE -ne 0) {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team [through a GitHub issue](https://github.com/martincostello/browserstack-automate/issues). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,14 +2,14 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.6.519" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.0.0-rc4" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.1" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/LICENSE
+++ b/LICENSE
@@ -175,17 +175,6 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
    Copyright 2015 Martin Costello
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/MartinCostello.BrowserStack.Automate.sln
+++ b/MartinCostello.BrowserStack.Automate.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		browserstack-logo.png = browserstack-logo.png
 		Build.ps1 = Build.ps1
 		build.sh = build.sh
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
@@ -45,6 +46,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{4CF8
 		.vscode\tasks.json = .vscode\tasks.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{11A7E733-D158-4529-B060-F16D1E4EC9E9}"
+	ProjectSection(SolutionItems) = preProject
+		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
+		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
+		.github\stale.yml = .github\stale.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{89AEF2C7-E8BE-471D-9B59-7F3878A6B542}"
+	ProjectSection(SolutionItems) = preProject
+		.github\ISSUE_TEMPLATE\bug_report.md = .github\ISSUE_TEMPLATE\bug_report.md
+		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +83,8 @@ Global
 		{DC723DF1-5852-45B1-B2BD-71BA85CDED1E} = {0F694B07-6EBF-45FB-99A0-266542E16DEE}
 		{73B410DF-CD59-407E-A8C3-2990F4ADA94C} = {14426345-2DE8-4450-A2F6-D23107D62989}
 		{4CF8E4EC-32C8-46DB-BDBF-4CEE57614DFE} = {14426345-2DE8-4450-A2F6-D23107D62989}
+		{11A7E733-D158-4529-B060-F16D1E4EC9E9} = {14426345-2DE8-4450-A2F6-D23107D62989}
+		{89AEF2C7-E8BE-471D-9B59-7F3878A6B542} = {11A7E733-D158-4529-B060-F16D1E4EC9E9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9E9EECDD-AA72-44DC-BA85-0CF401B72A99}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ deploy:
 
   - provider: NuGet
     api_key:
-      secure: BhD69WvO+PFmhWI1oEcTplDHGuQ4oUoULzPy4K3fdUGLUfZ1JCUyRE6/wQjjtBxN
+      secure: THNHTw3qtQXgSWiBS7JM5QNsO/59BuUUmej27zgoqLKVvZOdVf+0dfrho/jyBKmL
     artifact: /.*\.nupkg/
     skip_symbols: false
     on:


### PR DESCRIPTION
  1. Update code analyzers to `2.6.2`.
  1. Add GitHub community documentation.
  1. Update NuGet API key.
  1. Remove boilerplate from `LICENSE`.