### PR TITLE
Fix schema

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
+++ b/src/MartinCostello.BrowserStack.Automate/BrowserStackAutomateClient.cs
@@ -329,7 +329,11 @@ namespace MartinCostello.BrowserStack.Automate
                 using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
-                    return await DeserializeAsync<List<Build>>(response).ConfigureAwait(false);
+                    var builds = await DeserializeAsync<List<AutomationBuild>>(response).ConfigureAwait(false);
+
+                    return builds
+                        .Select((p) => p.Build)
+                        .ToList();
                 }
             }
         }
@@ -403,7 +407,9 @@ namespace MartinCostello.BrowserStack.Automate
                 using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
-                    return await DeserializeAsync<SessionDetail>(response).ConfigureAwait(false);
+                    var result = await DeserializeAsync<AutomationSessionDetail>(response).ConfigureAwait(false);
+
+                    return result?.SessionDetail;
                 }
             }
         }
@@ -523,7 +529,11 @@ namespace MartinCostello.BrowserStack.Automate
                 using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
-                    return await DeserializeAsync<List<Session>>(response).ConfigureAwait(false);
+                    var sessions = await DeserializeAsync<List<AutomationSession>>(response).ConfigureAwait(false);
+
+                    return sessions
+                        .Select((p) => p.Session)
+                        .ToList();
                 }
             }
         }
@@ -708,7 +718,9 @@ namespace MartinCostello.BrowserStack.Automate
                 using (var response = await Client.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     await EnsureSuccessAsync(response).ConfigureAwait(false);
-                    return await DeserializeAsync<Session>(response).ConfigureAwait(false);
+                    var session = await DeserializeAsync<AutomationSession>(response).ConfigureAwait(false);
+
+                    return session?.Session;
                 }
             }
         }
@@ -941,6 +953,42 @@ namespace MartinCostello.BrowserStack.Automate
                     return await DeserializeAsync<T>(response).ConfigureAwait(false);
                 }
             }
+        }
+
+        /// <summary>
+        /// A class representing a BrowserStack Automate build. This class cannot be inherited.
+        /// </summary>
+        private sealed class AutomationBuild
+        {
+            /// <summary>
+            /// Gets or sets the build.
+            /// </summary>
+            [JsonProperty("automation_build")]
+            public Build Build { get; set; }
+        }
+
+        /// <summary>
+        /// A class representing a BrowserStack Automate session. This class cannot be inherited.
+        /// </summary>
+        private sealed class AutomationSession
+        {
+            /// <summary>
+            /// Gets or sets the session.
+            /// </summary>
+            [JsonProperty("automation_session")]
+            public Session Session { get; set; }
+        }
+
+        /// <summary>
+        /// A class representing a BrowserStack Automate session's details. This class cannot be inherited.
+        /// </summary>
+        private sealed class AutomationSessionDetail
+        {
+            /// <summary>
+            /// Gets or sets the session.
+            /// </summary>
+            [JsonProperty("automation_session")]
+            public SessionDetail SessionDetail { get; set; }
         }
     }
 }

--- a/src/MartinCostello.BrowserStack.Automate/Session.cs
+++ b/src/MartinCostello.BrowserStack.Automate/Session.cs
@@ -26,7 +26,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets or sets the duration of the session in seconds.
         /// </summary>
-        [JsonProperty("duration")]
+        [JsonProperty("duration", NullValueHandling = NullValueHandling.Ignore)] // TODO Should be nullable, but don't want to break binary compatibility
         public int Duration { get; set; }
 
         /// <summary>

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -978,7 +978,7 @@ namespace MartinCostello.BrowserStack.Automate
             session.ProjectName.Should().NotBeNullOrEmpty();
             session.Reason.Should().NotBeNullOrEmpty();
             session.Status.Should().NotBeNullOrEmpty();
-            session.Duration.Should().BeGreaterThan(0);
+            session.Duration.Should().BeGreaterThan(-1);
         }
 
         /// <summary>


### PR DESCRIPTION
Looks like some things were missed from #21, and some parts were incompatible with the BrowserStack Automate API. Specifically:
  1. Builds and sessions are returned in a wrapper object.
  1. The duration of a session can be null.

To keep this fix as a patch release, rather than a `4.0.0`, `Session` is updated to ignore nulls, and the wrapper objects are deserialized internally and unwrapped so that the return types of `BrowserStackAutomateClient` are the same.