### PR TITLE
Publish NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,11 @@ jobs:
       with:
         name: packages-${{ matrix.os_name }}
         path: ./artifacts/packages
+
+    - name: Push NuGet packages to MyGet
+      run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.MYGET_TOKEN }} --skip-duplicate --source https://www.myget.org/F/martincostello/api/v2/package
+      if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && runner.os == 'Windows' }}
+
+    - name: Push NuGet packages to NuGet.org
+      run: dotnet nuget push "artifacts\packages\*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && runner.os == 'Windows' }}


### PR DESCRIPTION
Publish NuGet packages to MyGet for master and tags, and NuGet.org for only tags.
