### PR TITLE
Handle null as 0 for a few properties

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/AutomatePlanStatus.cs
+++ b/src/MartinCostello.BrowserStack.Automate/AutomatePlanStatus.cs
@@ -26,7 +26,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets or sets the number of parallel sessions currently running.
         /// </summary>
-        [JsonProperty("parallel_sessions_running")]
+        [JsonProperty("parallel_sessions_running", NullValueHandling = NullValueHandling.Ignore)]
         public int ParallelSessionsRunning { get; set; }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets or sets the number of parallel sessions currently queued.
         /// </summary>
-        [JsonProperty("queued_sessions")]
+        [JsonProperty("queued_sessions", NullValueHandling = NullValueHandling.Ignore)]
         public int QueuedParallelSessions { get; set; }
 
         /// <summary>

--- a/src/MartinCostello.BrowserStack.Automate/Build.cs
+++ b/src/MartinCostello.BrowserStack.Automate/Build.cs
@@ -26,7 +26,7 @@ namespace MartinCostello.BrowserStack.Automate
         /// <summary>
         /// Gets or sets the duration of the build, in seconds.
         /// </summary>
-        [JsonProperty("duration")]
+        [JsonProperty("duration", NullValueHandling = NullValueHandling.Ignore)]
         public int Duration { get; set; }
 
         /// <summary>

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/BrowserStackAutomateClientTests.cs
@@ -253,7 +253,7 @@ namespace MartinCostello.BrowserStack.Automate
                     build.Should().NotBeNull();
                     build.Should().NotBeNull();
                     build.CreatedAt.Should().BeOnOrAfter(project.CreatedAt);
-                    build.Duration.Should().BeGreaterOrEqualTo(1);
+                    build.Duration.Should().BeGreaterOrEqualTo(0);
                     build.Id.Should().BeGreaterThan(0);
                     build.HashedId.Should().NotBeNullOrEmpty();
                     build.Name.Should().NotBeNullOrEmpty();


### PR DESCRIPTION
The BrowserStack API appears to returning `null` rather than 0 for a selection of properties. This changes to the null handling of a few of the properties to "Ignore" to avoid any breaking changes.