### PR TITLE
Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "C# (.NET)",
+  "extensions": [
+    "editorconfig.editorconfig",
+    "ms-dotnettools.csharp",
+    "ms-vscode.PowerShell"
+  ],
+  "postCreateCommand": "./build.ps1 -SkipTests",
+  "remoteEnv": {
+    "PATH": "/root/.dotnet/tools:${containerWorkspaceFolder}/.dotnetcli:${containerEnv:PATH}"
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "editorconfig.editorconfig",
-    "ms-dotnettools.csharp"
+    "ms-dotnettools.csharp",
+    "ms-vscode.PowerShell"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "args": [
         "test"
       ],
-      "cwd": "${workspaceRoot}/tests/MartinCostello.BrowserStack.Automate.Tests",
+      "cwd": "${workspaceFolder}/tests/MartinCostello.BrowserStack.Automate.Tests",
       "console": "internalConsole",
       "stopAtEntry": false,
       "internalConsoleOptions": "openOnSessionStart"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,9 +19,11 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -114,10 +114,10 @@ function DotNetPack {
 function DotNetTest {
     param([string]$Project)
 
-    $nugetPath = Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages"
+    $nugetPath = $env:NUGET_PACKAGES ?? (Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages")
     $propsFile = Join-Path $solutionPath "Directory.Packages.props"
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
-    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\netcoreapp3.0\ReportGenerator.dll"
+    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\net5.0\ReportGenerator.dll"
 
     $coverageOutput = Join-Path $OutputPath "coverage.cobertura.xml"
     $reportOutput = Join-Path $OutputPath "coverage"


### PR DESCRIPTION
* Add support for GitHub Codespaces.
* Use the `NUGET_PACKAGES` environment variables for the NuGet package cache location if it is set.
* Only add a package references for `ReportGenerator` for test projects.
