### PR TITLE
Enable colour output from .NET CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ jobs:
         BrowserStack_UserName: ${{ secrets.BrowserStack_UserName }}
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
         NUGET_XMLDOC_MODE: skip
+        TERM: xterm
 
     - uses: codecov/codecov-action@v3
       name: Upload coverage to Codecov


### PR DESCRIPTION
Enable coloured output to the terminal in GitHub Actions for Linux and macOS.
