### PR TITLE
Bump Newtonsoft.Json to 13.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,8 +36,8 @@
     <SignAssembly>true</SignAssembly>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <VersionPrefix>3.0.4</VersionPrefix>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(IsTestProject)' != 'true' " />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(IsTestProject)' != 'true' " />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />


### PR DESCRIPTION
- Bump Newtonsoft.Json to 13.0.1 to resolve GHSA-5crp-9r3c-p9vr.
- Bump version to 4.0.0.
