### PR TITLE
Use HTTPS for NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![Alt text](browserstack-logo.png) BrowserStack Automate REST API .NET Client
 
-[![NuGet](https://buildstats.info/nuget/MartinCostello.BrowserStack.Automate)](http://www.nuget.org/packages/MartinCostello.BrowserStack.Automate)
+[![NuGet](https://buildstats.info/nuget/MartinCostello.BrowserStack.Automate)](https://www.nuget.org/packages/MartinCostello.BrowserStack.Automate)
 
 ## Build Status
 


### PR DESCRIPTION
Make the link to the NuGet package HTTPS.
