### PR TITLE
Remove repo_token

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -29,7 +29,6 @@ jobs:
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           publish_results: true
-          repo_token: ${{ secrets.OSSF_SCORECARD_TOKEN }}
           results_file: results.sarif
           results_format: sarif
 


### PR DESCRIPTION
Remove `repo_token` and use `GITHUB_TOKEN` instead for use with repository rulesets.
