### PR TITLE
Fix dependency

### DIFF
--- a/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
+++ b/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" VersionOverride="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />

--- a/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
+++ b/tests/MartinCostello.BrowserStack.Automate.Tests/MartinCostello.BrowserStack.Automate.Tests.csproj
@@ -3,7 +3,7 @@
     <Description>Tests for MartinCostello.BrowserStack.Automate.</Description>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1707;CA2007;SA1600;RS0016;RS0037</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CA2007;SA1600</NoWarn>
     <RootNamespace>MartinCostello.BrowserStack.Automate</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>MartinCostello.BrowserStack.Automate</UserSecretsId>


### PR DESCRIPTION
Fix Microsoft.CodeAnalysis.PublicApiAnalyzers being incorrectly included as a dependency of projects consuming the package.
