### PR TITLE
Dispose of client

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ public sealed class RequiresBrowserStackAutomateAttribute : FactAttribute
 
         if (userName is not null && accessKey is not null)
         {
-            var client = new BrowserStackAutomateClient(userName, accessKey);
+            using var client = new BrowserStackAutomateClient(userName, accessKey);
             var plan = client.GetStatusAsync().Result;
 
             if (plan.MaximumAllowedParallelSessions < 1 ||


### PR DESCRIPTION
Add `using` to code sample to avoid CA2000 warning.
