### PR TITLE
Add tools manifest for dotnet-validate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-validate": {
+      "version": "0.0.1-preview.304",
+      "commands": [
+        "dotnet-validate"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-validate-version: ${{ steps.get-dotnet-validate-version.outputs.dotnet-validate-version }}
 
     strategy:
       fail-fast: false
@@ -84,6 +85,13 @@ jobs:
         path: ./artifacts/package/release
         if-no-files-found: error
 
+    - name: Get dotnet-validate version
+      id: get-dotnet-validate-version
+      shell: pwsh
+      run: |
+        $dotnetValidateVersion = (Get-Content "./.config/dotnet-tools.json" | Out-String | ConvertFrom-Json).tools.'dotnet-validate'.version
+        "dotnet-validate-version=${dotnetValidateVersion}" >> $env:GITHUB_OUTPUT
+
   validate-packages:
     needs: build
     runs-on: ubuntu-latest
@@ -101,8 +109,10 @@ jobs:
 
     - name: Validate NuGet packages
       shell: pwsh
+      env:
+        DOTNET_VALIDATE_VERSION: ${{ needs.build.outputs.dotnet-validate-version }}
       run: |
-        dotnet tool install --global dotnet-validate --version 0.0.1-preview.304
+        dotnet tool install --global dotnet-validate --version ${env:DOTNET_VALIDATE_VERSION}
         $packages = Get-ChildItem -Filter "*.nupkg" | ForEach-Object { $_.FullName }
         $invalidPackages = 0
         foreach ($package in $packages) {


### PR DESCRIPTION
Add a .NET tools manifest for dotnet-validate so that dependabot can update it if there's ever a newer version released, and then reference that version in the build workflow.
