### PR TITLE
Bump packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,12 +7,12 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="ReportGenerator" Version="5.2.5" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />


### PR DESCRIPTION
Bump Microsoft.AspNetCore.WebUtilities and Microsoft.Extensions.Http.Resilience to their latest versions as dependabot is failing to do so.
