### PR TITLE
Bump Microsoft.AspNetCore.WebUtilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,5 @@ updates:
     - "martincostello"
   open-pull-requests-limit: 99
   ignore:
+    - dependency-name: Microsoft.AspNetCore.WebUtilities
     - dependency-name: System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.5.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />

--- a/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
+++ b/src/MartinCostello.BrowserStack.Automate/MartinCostello.BrowserStack.Automate.csproj
@@ -19,7 +19,7 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" VersionOverride="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" VersionOverride="2.3.0" />
     <PackageReference Include="System.Net.Http.Json" VersionOverride="8.0.0" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>


### PR DESCRIPTION
- Use Microsoft.AspNetCore.WebUtilities 2.3.0 for `netstandard2.0`.
- Bump Microsoft.AspNetCore.WebUtilities to 9.0.1 for tests.
- Ignore dependabot updates for Microsoft.AspNetCore.WebUtilities.
