### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: NuGet log in
-      uses: NuGet/login@d883674c922ba7e5cc0370927b10a33b67d54677 # v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
       id: nuget-login
       with:
         user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
Switch to using GitHub OIDC for pushing packages to NuGet.org with Trusted Publishing.

> Depends on Trusted Publishing rolling out to my NuGet account. ⏳
